### PR TITLE
Move batch support to Exandra.execute_batch/3

### DIFF
--- a/lib/exandra/batch.ex
+++ b/lib/exandra/batch.ex
@@ -12,10 +12,7 @@ defmodule Exandra.Batch do
   ## Usage
 
   To execute a batch of queries through Exandra, you can use the
-  `Ecto.Adapters.SQL.query/4` (or `Ecto.Adapters.SQL.query!/4`) function
-  and pass in a `Exandra.Batch` struct as the query. Alternatively, you
-  can use the `query/4` and `query!/4` functions that Ecto defines in your
-  `Ecto.Repo`. For example:
+  `Exandra.execute_batch/3`.
 
       batch = %Exandra.Batch{
         queries: [
@@ -24,7 +21,7 @@ defmodule Exandra.Batch do
         ]
       }
 
-      MyRepo.query!(batch)
+      Exandra.execute_batch(MyApp.Repo, batch)
 
   """
 

--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -97,37 +97,6 @@ defmodule Exandra.Connection do
   end
 
   @impl Ecto.Adapters.SQL.Connection
-  def query(cluster, %mod{queries: queries}, params, opts) when mod == Exandra.Batch do
-    if params != [] do
-      raise ArgumentError,
-            "when using an Exandra.Batch query, pass params to the queries " <>
-              "themselves, and not to the query/4 or query!/4 functions"
-    end
-
-    @xandra_cluster_mod.run(cluster, opts, fn conn ->
-      # First, prepare all queries (doesn't matter the order).
-      prepared_queries =
-        queries
-        |> Enum.uniq_by(fn {sql, _values} -> sql end)
-        |> Enum.reduce(%{}, fn {sql, _values}, acc ->
-          case @xandra_mod.prepare(conn, sql, opts) do
-            {:ok, %Prepared{} = prepared} -> Map.put(acc, sql, prepared)
-            {:error, reason} -> throw({:prepare_error, reason})
-          end
-        end)
-
-      # Now, add them all to a Xandra.Batch and execute the batch.
-      batch =
-        Enum.reduce(queries, Xandra.Batch.new(), fn {sql, values}, batch ->
-          Xandra.Batch.add(batch, Map.fetch!(prepared_queries, sql), values)
-        end)
-
-      @xandra_mod.execute(conn, batch)
-    end)
-  catch
-    {:prepare_error, reason} -> {:error, reason}
-  end
-
   def query(cluster, sql, params, opts) do
     sql =
       case sql do
@@ -150,6 +119,11 @@ defmodule Exandra.Connection do
         @xandra_mod.execute(conn, prepared, params, opts)
       end
     end)
+  end
+
+  @doc false
+  def checkout(cluster, fun, options) do
+    @xandra_cluster_mod.run(cluster, options, fun)
   end
 
   @impl Ecto.Adapters.SQL.Connection

--- a/test/exandra/integration_test.exs
+++ b/test/exandra/integration_test.exs
@@ -97,11 +97,11 @@ defmodule Exandra.IntegrationTest do
     end
   end
 
-  describe "executing a batch with Ecto.Adapters.SQL.query/4" do
-    test "works", %{start_opts: start_opts} do
+  describe "Exandra.execute_batch/3" do
+    test "executes a batch query", %{start_opts: start_opts} do
       start_supervised!({Exandra.TestRepo, start_opts})
 
-      TestRepo.query!("CREATE TABLE users (email varchar, PRIMARY KEY (email))")
+      TestRepo.query!("CREATE TABLE IF NOT EXISTS users (email varchar, PRIMARY KEY (email))")
 
       batch = %Exandra.Batch{
         queries: [
@@ -110,7 +110,7 @@ defmodule Exandra.IntegrationTest do
         ]
       }
 
-      Exandra.TestRepo.query!(batch)
+      assert Exandra.execute_batch(TestRepo, batch) == :ok
 
       assert %{num_rows: 2, rows: rows} = TestRepo.query!("SELECT email FROM users")
       assert rows == [["bob@example.com"], ["meg@example.com"]]


### PR DESCRIPTION
#20 broke the spec for the `Ecto.Adapters.SQL.query/4` callback.

This PR has to use a trick with `checkout/3`, which will be hopefully eventually fixed by this other PR I made in ecto_sql: https://github.com/elixir-ecto/ecto_sql/pull/534