### PR TITLE
Add Exandra.stream!/4

### DIFF
--- a/lib/exandra.ex
+++ b/lib/exandra.ex
@@ -334,8 +334,7 @@ defmodule Exandra do
   end
 
   @doc """
-  Streams the results of a simple query or a prepared query. One query is executed
-  for each page in the result set.
+  Streams the results of a simple query or a prepared query.
 
   See `Xandra.prepare!/4` and `Xandra.stream_pages!/4` for more information including
   supported options.

--- a/lib/exandra.ex
+++ b/lib/exandra.ex
@@ -356,8 +356,8 @@ defmodule Exandra do
         end
       )
   """
-  @spec stream!(String.t(), list(term()), atom(), Keyword.t()) :: Xandra.PageStream.t()
-  def stream!(sql, values, repo, opts \\ []) do
+  @spec stream!(Ecto.Repo.t(), String.t(), list(term()), Keyword.t()) :: Xandra.PageStream.t()
+  def stream!(repo, sql, values, opts \\ []) do
     %{pid: cluster_pid} = Ecto.Repo.Registry.lookup(repo.get_dynamic_repo())
     prepared = @xandra_cluster_mod.prepare!(cluster_pid, sql, opts)
 

--- a/lib/exandra/xandra_behaviour.ex
+++ b/lib/exandra/xandra_behaviour.ex
@@ -13,14 +13,4 @@ defmodule Exandra.XandraBehaviour do
 
   @callback prepare(Xandra.conn(), String.t(), keyword()) ::
               {:ok, Xandra.Prepared.t()} | {:error, Xandra.error()}
-
-  @callback prepare!(Xandra.conn(), String.t(), keyword()) ::
-              {:ok, Xandra.Prepared.t()} | {:error, Xandra.error()}
-
-  @callback stream_pages!(
-              cluster :: pid(),
-              stmt :: Xandra.statement() | Prepared.t(),
-              values :: Xandra.values(),
-              keyword :: keyword()
-            ) :: Enumerable.t()
 end

--- a/lib/exandra/xandra_behaviour.ex
+++ b/lib/exandra/xandra_behaviour.ex
@@ -13,4 +13,14 @@ defmodule Exandra.XandraBehaviour do
 
   @callback prepare(Xandra.conn(), String.t(), keyword()) ::
               {:ok, Xandra.Prepared.t()} | {:error, Xandra.error()}
+
+  @callback prepare!(Xandra.conn(), String.t(), keyword()) ::
+              {:ok, Xandra.Prepared.t()} | {:error, Xandra.error()}
+
+  @callback stream_pages!(
+              cluster :: pid(),
+              stmt :: Xandra.statement() | Prepared.t(),
+              values :: Xandra.values(),
+              keyword :: keyword()
+            ) :: Enumerable.t()
 end

--- a/lib/exandra/xandra_cluster_behaviour.ex
+++ b/lib/exandra/xandra_cluster_behaviour.ex
@@ -17,6 +17,9 @@ defmodule Exandra.XandraClusterBehaviour do
   @callback prepare(cluster :: pid(), stmt :: Xandra.statement(), keyword()) ::
               {:ok, Prepared.t()} | {:error, term()}
 
+  @callback prepare!(cluster :: pid(), stmt :: Xandra.statement(), keyword()) ::
+              {:ok, Prepared.t()} | {:error, term()}
+
   @callback stream_pages!(
               cluster :: pid(),
               stmt :: Xandra.statement() | Prepared.t(),

--- a/test/exandra/integration_test.exs
+++ b/test/exandra/integration_test.exs
@@ -148,7 +148,7 @@ defmodule Exandra.IntegrationTest do
       TestRepo.query!("INSERT INTO users (email) VALUES (?)", ["bob@example.com"])
       TestRepo.query!("INSERT INTO users (email) VALUES (?)", ["meg@example.com"])
 
-      assert %Xandra.PageStream{} = stream = Exandra.stream!("SELECT * FROM users", [], TestRepo)
+      assert %Xandra.PageStream{} = stream = Exandra.stream!(TestRepo, "SELECT * FROM users", [])
 
       emails =
         Enum.flat_map(
@@ -174,9 +174,9 @@ defmodule Exandra.IntegrationTest do
       assert %Xandra.PageStream{} =
                stream =
                Exandra.stream!(
+                 TestRepo,
                  "SELECT * FROM users",
                  [],
-                 TestRepo,
                  page_size: 2,
                  tracing: true
                )
@@ -199,8 +199,8 @@ defmodule Exandra.IntegrationTest do
       end
 
       assert [%{"email" => "bob@example.com"}] =
-               "SELECT * FROM users WHERE email = ?"
-               |> Exandra.stream!(["bob@example.com"], TestRepo)
+               TestRepo
+               |> Exandra.stream!("SELECT * FROM users WHERE email = ?", ["bob@example.com"])
                |> Enum.flat_map(&Enum.to_list/1)
     end
   end

--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -38,6 +38,7 @@ defmodule Exandra.AdapterCase do
     stub(XandraClusterMock, :child_spec, &Xandra.Cluster.child_spec/1)
     stub(XandraClusterMock, :execute, &Xandra.Cluster.execute/4)
     stub(XandraClusterMock, :prepare, &Xandra.Cluster.prepare/3)
+    stub(XandraClusterMock, :prepare!, &Xandra.Cluster.prepare!/3)
     stub(XandraClusterMock, :stream_pages!, &Xandra.Cluster.stream_pages!/4)
     stub(XandraClusterMock, :run, &Xandra.Cluster.run/2)
     stub(XandraClusterMock, :run, &Xandra.Cluster.run/3)
@@ -46,8 +47,6 @@ defmodule Exandra.AdapterCase do
     stub(XandraMock, :execute, &Xandra.execute/2)
     stub(XandraMock, :execute, &Xandra.execute/4)
     stub(XandraMock, :prepare, &Xandra.prepare/3)
-    stub(XandraMock, :prepare!, &Xandra.prepare!/3)
-    stub(XandraMock, :stream_pages!, &Xandra.stream_pages!/4)
 
     :ok
   end

--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -46,6 +46,8 @@ defmodule Exandra.AdapterCase do
     stub(XandraMock, :execute, &Xandra.execute/2)
     stub(XandraMock, :execute, &Xandra.execute/4)
     stub(XandraMock, :prepare, &Xandra.prepare/3)
+    stub(XandraMock, :prepare!, &Xandra.prepare!/3)
+    stub(XandraMock, :stream_pages!, &Xandra.stream_pages!/4)
 
     :ok
   end


### PR DESCRIPTION
This exposes the ability to stream results of a query using `Xandra.stream_pages!/4`

I went with this approach because after experimenting I ran into some blockers
- Ecto performs streaming within a transaction and will raise an error if you try without it.
- DBConnection will raise an error if you stream within a transaction since it's not supported.
- Xandra streams via `stream_pages!/4` which raises errors