### PR TITLE
Add support to multiple keyspaces using Ecto prefixes

### DIFF
--- a/lib/exandra.ex
+++ b/lib/exandra.ex
@@ -119,6 +119,12 @@ defmodule Exandra do
   Cassandra/Scylla, and allow you to run multiple queries in a single request.
   See `Exandra.Batch` for more information and examples.
 
+  ## Multiple keyspaces using prefixes
+
+  You can use [query prefixes](https://hexdocs.pm/ecto/multi-tenancy-with-query-prefixes.html) to
+  query different keyspaces using the same schemas. Note that, as indicated in the Ecto docs,
+  migrations must be run for _each_ prefix in this case.
+
   ## Migrations
 
   You can use Exandra to run migrations as well, as it supports most of the DDL-related

--- a/lib/exandra.ex
+++ b/lib/exandra.ex
@@ -122,8 +122,8 @@ defmodule Exandra do
   ## Multiple keyspaces using prefixes
 
   You can use [query prefixes](https://hexdocs.pm/ecto/multi-tenancy-with-query-prefixes.html) to
-  query different keyspaces using the same schemas. Note that, as indicated in the Ecto docs,
-  migrations must be run for _each_ prefix in this case.
+  query different keyspaces using the same schemas. As pointed out in the Ecto docs,
+  migrations must be run for *each* prefix in this case.
 
   ## Migrations
 

--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -200,7 +200,7 @@ defmodule Exandra.Connection do
   @impl Ecto.Adapters.SQL.Connection
   def update_all(query) do
     sources = create_names(query, [])
-    table = table_name(sources, 0)
+    table = table_name(sources)
     cte(query, sources)
     combinations(query)
 
@@ -280,7 +280,7 @@ defmodule Exandra.Connection do
   end
 
   defp from(%{from: %{source: {_from, _schema}, hints: hints}}, sources) do
-    table = table_name(sources, 0)
+    table = table_name(sources)
     {[" FROM " | table], Enum.map(hints, &[?\s | &1])}
   end
 
@@ -821,8 +821,8 @@ defmodule Exandra.Connection do
     "DROP #{quote_name(name)}"
   end
 
-  defp table_name(sources, idx) do
-    {table, _name, _schema} = elem(sources, idx)
+  defp table_name(sources) do
+    {table, _name, _schema} = elem(sources, 0)
     table
   end
 

--- a/test/exandra/connection_test.exs
+++ b/test/exandra/connection_test.exs
@@ -211,13 +211,16 @@ defmodule Exandra.ConnectionTest do
   end
 
   test "all with prefix" do
-    query =
-      Schema |> select([r], r.x) |> Queryable.to_query() |> Map.put(:prefix, "prefix") |> plan()
+    query = Schema |> select([r], r.x) |> Ecto.Query.put_query_prefix("prefix") |> plan()
 
     assert all(query) == ~s{SELECT x FROM prefix.schema}
 
     query =
-      Schema |> from(prefix: "first") |> select([r], r.x) |> Map.put(:prefix, "prefix") |> plan()
+      Schema
+      |> from(prefix: "first")
+      |> select([r], r.x)
+      |> Ecto.Query.put_query_prefix("prefix")
+      |> plan()
 
     assert all(query) == ~s{SELECT x FROM first.schema}
 
@@ -575,7 +578,9 @@ defmodule Exandra.ConnectionTest do
 
   test "update all with prefix" do
     query =
-      from(m in Schema, update: [set: [x: 0]]) |> Map.put(:prefix, "prefix") |> plan(:update_all)
+      from(m in Schema, update: [set: [x: 0]])
+      |> Ecto.Query.put_query_prefix("prefix")
+      |> plan(:update_all)
 
     assert update_all(query) == ~s{UPDATE prefix.schema SET x = 0}
   end
@@ -591,10 +596,10 @@ defmodule Exandra.ConnectionTest do
   end
 
   test "delete all with prefix" do
-    query = Schema |> Queryable.to_query() |> Map.put(:prefix, "prefix") |> plan()
+    query = Schema |> Ecto.Query.put_query_prefix("prefix") |> plan()
     assert delete_all(query) == ~s{DELETE FROM prefix.schema}
 
-    query = Schema |> from(prefix: "first") |> Map.put(:prefix, "prefix") |> plan()
+    query = Schema |> from(prefix: "first") |> Ecto.Query.put_query_prefix("prefix") |> plan()
     assert delete_all(query) == ~s{DELETE FROM first.schema}
   end
 

--- a/test/exandra/connection_test.exs
+++ b/test/exandra/connection_test.exs
@@ -210,6 +210,21 @@ defmodule Exandra.ConnectionTest do
     end
   end
 
+  test "all with prefix" do
+    query =
+      Schema |> select([r], r.x) |> Queryable.to_query() |> Map.put(:prefix, "prefix") |> plan()
+
+    assert all(query) == ~s{SELECT x FROM prefix.schema}
+
+    query =
+      Schema |> from(prefix: "first") |> select([r], r.x) |> Map.put(:prefix, "prefix") |> plan()
+
+    assert all(query) == ~s{SELECT x FROM first.schema}
+
+    query = "posts" |> from(prefix: "prefix") |> select([r], r.x) |> plan()
+    assert all(query) == ~s{SELECT x FROM prefix.posts}
+  end
+
   test "select" do
     query = Schema |> select([r], {r.x, r.y}) |> plan()
     assert all(query) == ~s{SELECT x, y FROM schema}
@@ -558,6 +573,13 @@ defmodule Exandra.ConnectionTest do
     assert update_all(query) == ~s{UPDATE schema SET x = 0}
   end
 
+  test "update all with prefix" do
+    query =
+      from(m in Schema, update: [set: [x: 0]]) |> Map.put(:prefix, "prefix") |> plan(:update_all)
+
+    assert update_all(query) == ~s{UPDATE prefix.schema SET x = 0}
+  end
+
   test "delete all" do
     query = Schema |> Queryable.to_query() |> plan()
     assert delete_all(query) == ~s{DELETE FROM schema}
@@ -566,6 +588,14 @@ defmodule Exandra.ConnectionTest do
 
     assert delete_all(query) ==
              ~s{DELETE FROM schema WHERE x = 123}
+  end
+
+  test "delete all with prefix" do
+    query = Schema |> Queryable.to_query() |> Map.put(:prefix, "prefix") |> plan()
+    assert delete_all(query) == ~s{DELETE FROM prefix.schema}
+
+    query = Schema |> from(prefix: "first") |> Map.put(:prefix, "prefix") |> plan()
+    assert delete_all(query) == ~s{DELETE FROM first.schema}
   end
 
   ## Partitions and windows
@@ -603,16 +633,25 @@ defmodule Exandra.ConnectionTest do
 
     query = insert(nil, "schema", [], [[]], {:raise, [], []}, [])
     assert query == ~s{INSERT INTO schema () VALUES () }
+
+    query = insert("prefix", "schema", [], [[]], {:raise, [], []}, [])
+    assert query == ~s{INSERT INTO prefix.schema () VALUES () }
   end
 
   test "update" do
     query = update(nil, "schema", [:id], [x: 1, y: 2], [])
     assert query == ~s{UPDATE schema SET id = ? WHERE x = ? AND y = ?}
+
+    query = update("prefix", "schema", [:id], [x: 1, y: 2], [])
+    assert query == ~s{UPDATE prefix.schema SET id = ? WHERE x = ? AND y = ?}
   end
 
   test "delete" do
     query = delete(nil, "schema", [x: 1, y: 2], [])
     assert query == ~s{DELETE FROM schema WHERE x = ? AND y = ?}
+
+    query = delete("prefix", "schema", [x: 1, y: 2], [])
+    assert query == ~s{DELETE FROM prefix.schema WHERE x = ? AND y = ?}
   end
 
   test "table_exists_query/1" do

--- a/test/exandra/prefix_test.exs
+++ b/test/exandra/prefix_test.exs
@@ -1,0 +1,53 @@
+defmodule Exandra.PrefixTest do
+  use Exandra.AdapterCase
+
+  import Ecto.Query, warn: false
+  import Mox
+
+  alias Exandra.TestRepo
+
+  defmodule MySchema do
+    use Ecto.Schema
+
+    @schema_prefix "foo"
+    @primary_key {:id, :binary_id, autogenerate: true}
+    schema "my_schema" do
+      field :my_string, :string
+    end
+  end
+
+  setup do
+    start_link_supervised!({TestRepo, host: "localhost", port: @port, keyspace: "unused"})
+    :ok
+  end
+
+  describe "schema prefix" do
+    setup do
+      # We're only interested in the prepared statement here, so we stub execution
+      XandraMock
+      |> stub(:execute, fn _conn, _stmt, _values, _opts -> {:ok, %Xandra.Void{}} end)
+
+      :ok
+    end
+
+    test "adds a keyspace to the table" do
+      XandraMock
+      |> expect(:prepare, fn _conn, stmt, _opts ->
+        assert "INSERT INTO foo.my_schema (my_string, id) VALUES (?, ?) " = stmt
+        {:ok, %Xandra.Prepared{}}
+      end)
+
+      TestRepo.insert(%MySchema{my_string: "string"})
+    end
+
+    test "can be overridden by query options" do
+      XandraMock
+      |> expect(:prepare, fn _conn, stmt, _options ->
+        assert "INSERT INTO bar.my_schema (my_string, id) VALUES (?, ?) " = stmt
+        {:ok, %Xandra.Prepared{}}
+      end)
+
+      TestRepo.insert(%MySchema{my_string: "string"}, prefix: "bar")
+    end
+  end
+end

--- a/test/exandra/prefix_test.exs
+++ b/test/exandra/prefix_test.exs
@@ -24,7 +24,7 @@ defmodule Exandra.PrefixTest do
   describe "schema prefix" do
     setup do
       # We're only interested in the prepared statement here, so we stub execution
-      stub(XandraMock :execute, fn _conn, _stmt, _values, _opts -> {:ok, %Xandra.Void{}} end)
+      stub(XandraMock, :execute, fn _conn, _stmt, _values, _opts -> {:ok, %Xandra.Void{}} end)
 
       :ok
     end

--- a/test/exandra/prefix_test.exs
+++ b/test/exandra/prefix_test.exs
@@ -24,30 +24,27 @@ defmodule Exandra.PrefixTest do
   describe "schema prefix" do
     setup do
       # We're only interested in the prepared statement here, so we stub execution
-      XandraMock
-      |> stub(:execute, fn _conn, _stmt, _values, _opts -> {:ok, %Xandra.Void{}} end)
+      stub(XandraMock :execute, fn _conn, _stmt, _values, _opts -> {:ok, %Xandra.Void{}} end)
 
       :ok
     end
 
     test "adds a keyspace to the table" do
-      XandraMock
-      |> expect(:prepare, fn _conn, stmt, _opts ->
+      expect(XandraMock, :prepare, fn _conn, stmt, _opts ->
         assert "INSERT INTO foo.my_schema (my_string, id) VALUES (?, ?) " = stmt
         {:ok, %Xandra.Prepared{}}
       end)
 
-      TestRepo.insert(%MySchema{my_string: "string"})
+      assert {:ok, _} = TestRepo.insert(%MySchema{my_string: "string"})
     end
 
     test "can be overridden by query options" do
-      XandraMock
-      |> expect(:prepare, fn _conn, stmt, _options ->
+      expect(XandraMock, :prepare, fn _conn, stmt, _options ->
         assert "INSERT INTO bar.my_schema (my_string, id) VALUES (?, ?) " = stmt
         {:ok, %Xandra.Prepared{}}
       end)
 
-      TestRepo.insert(%MySchema{my_string: "string"}, prefix: "bar")
+      assert {:ok, _} = TestRepo.insert(%MySchema{my_string: "string"}, prefix: "bar")
     end
   end
 end

--- a/test/exandra/querying_test.exs
+++ b/test/exandra/querying_test.exs
@@ -120,5 +120,12 @@ defmodule Exandra.QueryingTest do
       assert sql == "DELETE FROM my_schema WHERE id = ?"
       assert params == [Ecto.UUID.dump!(uuid)]
     end
+
+    test "with prefix" do
+      query = from(s in MySchema, prefix: "prefix")
+
+      {sql, _params} = TestRepo.to_sql(:all, query)
+      assert sql =~ "FROM prefix.my_schema"
+    end
   end
 end

--- a/test/exandra/querying_test.exs
+++ b/test/exandra/querying_test.exs
@@ -125,7 +125,7 @@ defmodule Exandra.QueryingTest do
       query = from(s in MySchema, prefix: "prefix")
 
       {sql, _params} = TestRepo.to_sql(:all, query)
-      assert sql =~ "FROM prefix.my_schema"
+      assert String.ends_with?(sql, "FROM prefix.my_schema")
     end
   end
 end


### PR DESCRIPTION
This allows using Exandra to query schemas across keyspaces.
Close #34.