### PR TITLE
[PATCH] ALTER migrations now follow CQL rules

### DIFF
--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -824,10 +824,10 @@ defmodule Exandra.Connection do
     end
   end
 
-  def create_column_definitions([]),
-    do: raise(RuntimeError, "you must define at least one column")
+  defp create_column_definitions([]),
+    do: raise("you must define at least one column")
 
-  def create_column_definitions(columns) do
+  defp create_column_definitions(columns) do
     Enum.map_join(columns, ", ", &column_definition(&1, false))
   end
 

--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -806,7 +806,7 @@ defmodule Exandra.Connection do
         MapSet.size(total_ops) > 1 ->
           "Exandra does not support more than one type of operation at a time. Found #{inspect(MapSet.to_list(total_ops))}"
 
-        op in [:modify, :rename] && columms_affected != 1 ->
+        op in [:modify, :rename] and columms_affected != 1 ->
           "Exandra only supports multiple column alters when using :add, or :remove"
 
         true ->

--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -791,7 +791,7 @@ defmodule Exandra.Connection do
     |> Enum.map(fn {_, name, _, opts} -> %{name: name, opts: opts} end)
   end
 
-  def alter_column_definitions([]), do: raise(RuntimeError, "you must define at least one column")
+  def alter_column_definitions([]), do: raise("you must define at least one column")
 
   def alter_column_definitions(columns) do
     {total_ops, columms_affected} =

--- a/test/exandra/connection_test.exs
+++ b/test/exandra/connection_test.exs
@@ -710,6 +710,12 @@ defmodule Exandra.ConnectionTest do
     assert_raise RuntimeError, "you must define at least one column", fn ->
       execute_ddl(create)
     end
+
+    alter = {:alter, table(:posts), []}
+
+    assert_raise RuntimeError, "you must define at least one column", fn ->
+      execute_ddl(alter)
+    end
   end
 
   test "create table with reference raises an exception" do

--- a/test/exandra/connection_test.exs
+++ b/test/exandra/connection_test.exs
@@ -526,6 +526,7 @@ defmodule Exandra.ConnectionTest do
 
   test "string type" do
     query = Schema |> select([], type(^"test", :string)) |> plan()
+
     assert all(query) == ~s{SELECT CAST(? AS text) FROM schema}
   end
 
@@ -1080,26 +1081,91 @@ defmodule Exandra.ConnectionTest do
     end
   end
 
-  test "alter table" do
+  test "alter table with more that one type of alter raises" do
     alter =
       {:alter, table(:posts),
        [
-         {:add, :title, :string, [default: "Untitled", size: 100, null: false]},
-         {:modify, :price, :decimal, [precision: 8, scale: 2, null: true]},
-         {:modify, :cost, :integer, [null: false, default: nil]},
+         {:add, :title, :string, []},
+         {:modify, :price, :decimal, []},
+         {:modify, :cost, :integer, []},
          {:modify, :status, :string, from: :integer},
          {:remove, :summary},
          {:remove, :body, :text, []}
        ]}
 
+    assert_raise ArgumentError,
+                 "Exandra does not support more than one type of operation at a time. Found [:add, :modify, :remove]",
+                 fn ->
+                   execute_ddl(alter)
+                 end
+  end
+
+  test "alter table with multiples" do
+    alter =
+      {:alter, table(:posts),
+       [
+         {:add, :title, :string, []},
+         {:add, :price, :decimal, []}
+       ]}
+
     assert execute_ddl(alter) == [
              """
-             ALTER TABLE posts ADD title text,
-             ALTER price TYPE decimal,
-             ALTER cost TYPE int,
-             ALTER status TYPE text,
-             DROP summary,
-             DROP body
+             ALTER TABLE posts ADD (title text, price decimal)
+             """
+             |> remove_newlines
+           ]
+
+    alter =
+      {:alter, table(:posts),
+       [
+         {:remove, :title},
+         {:remove, :price}
+       ]}
+
+    assert execute_ddl(alter) == [
+             """
+             ALTER TABLE posts DROP (title, price)
+             """
+             |> remove_newlines
+           ]
+  end
+
+  test "alter table with single operations" do
+    alter =
+      {:alter, table(:posts),
+       [
+         {:add, :title, :string, []}
+       ]}
+
+    assert execute_ddl(alter) == [
+             """
+             ALTER TABLE posts ADD title text
+             """
+             |> remove_newlines
+           ]
+
+    alter =
+      {:alter, table(:posts),
+       [
+         {:remove, :title}
+       ]}
+
+    assert execute_ddl(alter) == [
+             """
+             ALTER TABLE posts DROP title
+             """
+             |> remove_newlines
+           ]
+
+    alter =
+      {:alter, table(:posts),
+       [
+         {:modify, :price, :decimal, []}
+       ]}
+
+    assert execute_ddl(alter) == [
+             """
+             ALTER TABLE posts ALTER price TYPE decimal
              """
              |> remove_newlines
            ]
@@ -1110,13 +1176,12 @@ defmodule Exandra.ConnectionTest do
       {:alter, table(:posts, prefix: :foo),
        [
          {:add, :author_id, :uuid, []},
-         {:modify, :permalink_id, :string, []}
+         {:add, :permalink_id, :string, []}
        ]}
 
     assert execute_ddl(alter) == [
              """
-             ALTER TABLE foo.posts ADD author_id uuid,
-             ALTER permalink_id TYPE text
+             ALTER TABLE foo.posts ADD (author_id uuid, permalink_id text)
              """
              |> remove_newlines
            ]


### PR DESCRIPTION
# What's new?
- CQL ALTER rules are now enforced.
- CQL ALTERS are now formatted correctly.