### PR TITLE
 Support for composite/custom types in type parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,21 +94,27 @@ field :home_phone, Exandra.UDT, type: :phone_number
 field :office_phone, Exandra.UDT, type: :phone_number
 ```
 
-### Arrays
+### Tuples
 
-You can use arrays with the Ecto `{:array, <type>}` type. This gets translated to the
-`list<_>` native Cassandra/Scylla type. For example, you can declare a field as
+Tuples can be declared using the `Exandra.Tuple` type.
 
 ```elixir
-field :checkins, {:array, :utc_datetime}
+field :version, Exandra.Tuple, types: [:integer, :integer, :integer]
 ```
 
-This field will use the native type `list<timestamp>`.
+### Native Collections (Lists, Maps, Sets)
 
-  > #### Exandra Types {: .tip}
-  >
-  > If you want to use actual Cassandra/Scylla types such as `map<_, _>` or
-  > `set<_>`, you can use the corresponding Exandra types `Exandra.Map` and `Exandra.Set`.
+Access to native Cassandra/Scylla collections is available
+using the appropriate data types in the field definition.
+
+```elixir
+@primary_key false
+schema "hotels" do
+  field :checkins, {:array, :utc_datetime}                            # list<timestamp>
+  field :room_to_customer, Exandra.Map, key: :integer, value: :string # map<int, string>
+  field :available_rooms, Exandra.Set, type: :integer                 # set<int>
+end
+```
 
 ### Counter Tables
 

--- a/lib/exandra.ex
+++ b/lib/exandra.ex
@@ -96,19 +96,45 @@ defmodule Exandra do
 
       field :home_phone, Exandra.EmbeddedType, cardinality: :many, using: MyApp.PhoneSchema
 
-  ### Arrays
+  ### Tuples
 
-  You can use arrays with the Ecto `{:array, <type>}` type. This gets translated to the
-  `list<_>` native Cassandra/Scylla type. For example, you can declare a field as
+  Tuples can be declared using the `Exandra.Tuple` type.
 
-      field :checkins, {:array, :utc_datetime}
+  ```elixir
+  field :version, Exandra.Tuple, types: [:integer, :integer, :integer]
+  ```
 
-  This field will use the native type `list<timestamp>`.
+  ### Native Collections (Lists, Maps, Sets)
 
-  > #### Exandra Types {: .tip}
+  Access to native Cassandra/Scylla collections is available
+  using the appropriate data types in the field definition.
+
+  ```elixir
+  @primary_key false
+  schema "hotels" do
+   field :checkins, {:array, :utc_datetime}                            # list<timestamp>
+   field :room_to_customer, Exandra.Map, key: :integer, value: :string # map<int, string>
+   field :available_rooms, Exandra.Set, type: :integer                 # set<int>
+  end
+  ```
+
+  > #### Composite Collections {: .tip}
   >
-  > If you want to use actual Cassandra/Scylla types such as `map<_, _>` or
-  > `set<_>`, you can use the corresponding Exandra types `Exandra.Map` and `Exandra.Set`.
+  > It's possible to create composite collections using the following syntax:
+  >
+  > ```elixir
+  > field :complex_type, {:array, Exandra.Map}, key: :string, value: Exandra.Set, type: :integer
+  > ```
+  >
+  > This creates a `list<map<tuple<integer>, set<string>>>`.
+  >
+  > However, please note that due to the limited expressivity of this representation,
+  > each collection at the same level will have the same typing information:
+  >
+  > ```elixir
+  > field :valid, Exandra.Set, type: Exandra.Set, type: :integer                                     # set<set<int>>
+  > field :invalid, Exandra.Map, key: Exandra.Set, type: :integer, value: Exandra.Set, type: :string # map<set<int>, set<int>> not map<set<int>, set<string>>
+  > ```
 
   ### Counter Tables
 

--- a/lib/exandra/map.ex
+++ b/lib/exandra/map.ex
@@ -1,12 +1,12 @@
 defmodule Exandra.Map do
   opts_schema = [
     key: [
-      type: :atom,
+      type: :any,
       required: true,
       doc: "The type of the keys in the map."
     ],
     value: [
-      type: :atom,
+      type: :any,
       required: true,
       doc: "The type of the values in the map."
     ],
@@ -37,6 +37,8 @@ defmodule Exandra.Map do
 
   use Ecto.ParameterizedType
 
+  alias Exandra.Types
+
   @opts_schema NimbleOptions.new!(opts_schema)
 
   # Made public for testing.
@@ -45,7 +47,16 @@ defmodule Exandra.Map do
 
   @impl Ecto.ParameterizedType
   def init(opts) do
+    {key, opts} = Keyword.pop_first(opts, :key)
+    {value, opts} = Keyword.pop_first(opts, :value)
+
+    key = Types.check_type!(__MODULE__, key, opts)
+    value = Types.check_type!(__MODULE__, value, opts)
+
     opts
+    |> Keyword.put(:key, key)
+    |> Keyword.put(:value, value)
+    |> Keyword.take(Keyword.keys(@opts_schema.schema))
     |> NimbleOptions.validate!(@opts_schema)
     |> Map.new()
   end

--- a/lib/exandra/set.ex
+++ b/lib/exandra/set.ex
@@ -1,7 +1,7 @@
 defmodule Exandra.Set do
   opts_schema = [
     type: [
-      type: :atom,
+      type: :any,
       required: true,
       doc: "The type of the elements in the set."
     ],
@@ -33,6 +33,8 @@ defmodule Exandra.Set do
 
   use Ecto.ParameterizedType
 
+  alias Exandra.Types
+
   @type t() :: MapSet.t()
 
   @opts_schema NimbleOptions.new!(opts_schema)
@@ -46,7 +48,12 @@ defmodule Exandra.Set do
 
   @impl Ecto.ParameterizedType
   def init(opts) do
+    {type, opts} = Keyword.pop_first(opts, :type)
+    checked_type = Types.check_type!(__MODULE__, type, opts)
+
     opts
+    |> Keyword.put(:type, checked_type)
+    |> Keyword.take(Keyword.keys(@opts_schema.schema))
     |> NimbleOptions.validate!(@opts_schema)
     |> Map.new()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Exandra.MixProject do
         source_ref: "v#{@version}",
         source_url: @repo_url,
         groups_for_modules: [
-          "Ecto types": [Exandra.UDT, Exandra.Counter, Exandra.Map, Exandra.Set]
+          "Ecto types": [Exandra.UDT, Exandra.Counter, Exandra.Map, Exandra.Set, Exandra.Tuple]
         ]
       ]
     ]

--- a/test/exandra/integration_test.exs
+++ b/test/exandra/integration_test.exs
@@ -24,6 +24,11 @@ defmodule Exandra.IntegrationTest do
         type: :my_complex,
         encoded_fields: [:meta]
 
+      field :my_composite, Exandra.Map,
+        key: Exandra.Tuple,
+        types: [:string, :integer],
+        value: :integer
+
       field :my_complex_udt, Exandra.UDT, type: :my_complex, encoded_fields: [:meta]
       field :my_list, {:array, :string}
       field :my_utc, :utc_datetime_usec
@@ -94,6 +99,7 @@ defmodule Exandra.IntegrationTest do
       my_complex_list_udt list<FROZEN<my_complex>>,
       my_complex_udt my_complex,
       my_tuple tuple<int, text>,
+      my_composite map<FROZEN<tuple<ascii, int>>, bigint>,
       my_embedded_udt my_embedded_type,
       my_list list<varchar>,
       my_utc timestamp,
@@ -278,6 +284,7 @@ defmodule Exandra.IntegrationTest do
         meta: %{"foo" => "bar", "baz" => %{"qux" => "quux"}},
         happened: ~U[2020-01-01T00:00:00Z]
       },
+      my_composite: %{{"foo", 1} => 1, {"bar", 8} => 4},
       my_bool: true,
       my_integer: 4,
       my_decimal: decimal1,
@@ -301,6 +308,7 @@ defmodule Exandra.IntegrationTest do
         meta: %{"foo" => "bar", "baz" => %{"qux" => "quux"}},
         happened: ~U[2020-01-01T00:00:00Z]
       },
+      my_composite: %{{"baz", 0} => 2},
       my_bool: false,
       my_integer: 5,
       my_decimal: decimal2,
@@ -319,6 +327,7 @@ defmodule Exandra.IntegrationTest do
       my_tuple: nil,
       my_complex_list_udt: nil,
       my_complex_udt: nil,
+      my_composite: nil,
       my_bool: nil,
       # my_integer is used for sorting.
       my_integer: 6,
@@ -354,6 +363,7 @@ defmodule Exandra.IntegrationTest do
                "meta" => %{"foo" => "bar", "baz" => %{"qux" => "quux"}},
                "happened" => ~U[2020-01-01T00:00:00.000Z]
              },
+             my_composite: %{{"bar", 8} => 4, {"foo", 1} => 1},
              my_bool: true,
              my_integer: 4,
              my_decimal: ^decimal1,
@@ -381,6 +391,7 @@ defmodule Exandra.IntegrationTest do
                "meta" => %{"foo" => "bar", "baz" => %{"qux" => "quux"}},
                "happened" => ~U[2020-01-01T00:00:00.000Z]
              },
+             my_composite: %{{"baz", 0} => 2},
              my_bool: false,
              my_integer: 5,
              my_decimal: ^decimal2,
@@ -399,6 +410,7 @@ defmodule Exandra.IntegrationTest do
              my_udt: %{},
              my_list_udt: nil,
              my_complex_list_udt: nil,
+             my_composite: %{},
              my_complex_udt: %{"meta" => %{}},
              my_bool: nil,
              my_integer: 6,

--- a/test/exandra/types/map_test.exs
+++ b/test/exandra/types/map_test.exs
@@ -10,7 +10,7 @@ defmodule Exandra.MapTest do
       field :my_int_key_map, Exandra.Map, key: :integer, value: :string
       field :my_int_value_map, Exandra.Map, key: :string, value: :integer
       field :my_int_map, Exandra.Map, key: :integer, value: :integer
-      field :my_atom_map, Exandra.Map, key: :atom, value: :integer
+      field :my_map_of_sets, Exandra.Map, key: Exandra.Set, type: :integer, value: :integer
     end
   end
 
@@ -19,12 +19,12 @@ defmodule Exandra.MapTest do
              :parameterized,
              Map,
              %{
-               field: :my_atom_map,
-               key: :atom,
+               field: :my_int_key_map,
+               key: :integer,
                schema: Schema,
-               value: :integer
+               value: :string
              }
-           } = Schema.__schema__(:type, :my_atom_map)
+           } = Schema.__schema__(:type, :my_int_key_map)
   end
 
   @p_dump_type {:parameterized, Map, Map.params(:dump)}
@@ -38,11 +38,11 @@ defmodule Exandra.MapTest do
     assert :self = Ecto.Type.embed_as(@p_self_type, :foo)
     assert :self = Ecto.Type.embed_as(@p_dump_type, :foo)
 
-    type = Schema.__schema__(:type, :my_atom_map)
-    assert {:ok, %{}} = Ecto.Type.load(type, :my_atom_map)
+    type = Schema.__schema__(:type, :my_int_key_map)
+    assert {:ok, %{}} = Ecto.Type.load(type, :my_int_key_map)
 
-    type = Schema.__schema__(:type, :my_int_map)
-    assert Ecto.Type.dump(type, %{1 => 3}) == {:ok, %{1 => 3}}
+    type = Schema.__schema__(:type, :my_int_key_map)
+    assert Ecto.Type.dump(type, %{1 => "a"}) == {:ok, %{1 => "a"}}
   end
 
   test "type/1" do

--- a/test/exandra/types/set_test.exs
+++ b/test/exandra/types/set_test.exs
@@ -67,6 +67,12 @@ defmodule Exandra.SetTest do
     assert {:ok, MapSet.new([1])} == Set.cast(1, %{type: :integer})
     assert {:ok, MapSet.new([1])} == Set.cast([1], %{type: :integer})
     assert :error = Set.cast(:asd, nil)
+
+    assert {:ok, MapSet.new([[1, 2, 3], [4, 5, 6]])} ==
+             Set.cast([[1, 2, 3], [4, 5, 6]], %{type: {:array, :integer}})
+
+    assert {:ok, MapSet.new([MapSet.new([1, 2, 3]), MapSet.new([4, 5, 6])])} ==
+             Set.cast([[1, 2, 3], [4, 5, 6]], %{type: {:parameterized, Set, %{type: :integer}}})
   end
 
   test "equal?/3" do

--- a/test/exandra/types/tuple_test.exs
+++ b/test/exandra/types/tuple_test.exs
@@ -53,6 +53,17 @@ defmodule Exandra.TupleTest do
     assert {:ok, {1}} == Tuple.cast([1], %{types: [:integer]})
 
     assert {:ok, {1, "a"}} == Tuple.cast({1, "a"}, %{types: [:integer, :string]})
+
+    assert {:ok, {MapSet.new([1]), %{2 => 3}, [4], {5}, 6}} ==
+             Tuple.cast({[1], %{2 => 3}, [4], 5, 6}, %{
+               types: [
+                 {:parameterized, Exandra.Set, %{type: :integer}},
+                 {:parameterized, Exandra.Map, %{key: :integer, value: :integer}},
+                 {:array, :integer},
+                 {:parameterized, Exandra.Tuple, %{types: [:integer]}},
+                 :integer
+               ]
+             })
   end
 
   test "load/2" do

--- a/test/exandra/types_test.exs
+++ b/test/exandra/types_test.exs
@@ -30,4 +30,42 @@ defmodule Exandra.TypesTest do
     # With types that are modules that export the type/0 callback.
     assert Types.for(Exandra.Counter) == {:ok, "counter"}
   end
+
+  test "check_type!/3" do
+    assert Types.check_type!(nil, :string, []) == :string
+
+    assert Types.check_type!(nil, {:array, Exandra.Set}, type: :integer) ==
+             {:array, {:parameterized, Exandra.Set, %{type: :integer}}}
+
+    assert Types.check_type!(nil, Exandra.Set, type: :integer) ==
+             {:parameterized, Exandra.Set, %{type: :integer}}
+
+    assert Types.check_type!(nil, Exandra.Map, key: Exandra.Set, type: :integer, value: :integer) ==
+             {:parameterized, Exandra.Map,
+              %{key: {:parameterized, Exandra.Set, %{type: :integer}}, value: :integer}}
+
+    assert Types.check_type!(nil, Exandra.Set, type: Exandra.Set, type: :integer) ==
+             {:parameterized, Exandra.Set,
+              %{type: {:parameterized, Exandra.Set, %{type: :integer}}}}
+
+    assert Types.check_type!(nil, Exandra.Tuple,
+             types: [:integer, Exandra.Set, Exandra.Map],
+             type: :string,
+             key: :integer,
+             value: :binary_id
+           ) ==
+             {:parameterized, Exandra.Tuple,
+              %{
+                types: [
+                  :integer,
+                  {:parameterized, Exandra.Set, %{type: :string}},
+                  {:parameterized, Exandra.Map, %{key: :integer, value: :binary_id}}
+                ]
+              }}
+
+    assert_raise ArgumentError, fn -> Types.check_type!(nil, :nonexsisting, []) end
+    assert_raise ArgumentError, fn -> Types.check_type!(nil, {:array, :nonexisting}, []) end
+    assert_raise ArgumentError, fn -> Types.check_type!(nil, {:nonexisting, :string}, []) end
+    assert_raise ArgumentError, fn -> Types.check_type!(nil, Exandra.Types, []) end
+  end
 end


### PR DESCRIPTION
Allow Exandra sets/maps/tuples to have composite/custom type parameters.

The logic is based on [ecto's](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/schema.ex#L2443) so that the behavior is similar to standard `{:array, Custom}` declarations.

This comes with the drawback that it's impossible to declare different parameters for elements of the same type at the same level, for example in
```elixir
  field :f, Exandra.Map, key: Exandra.Set, type: :integer, value: Exandra.Set, type: :string
```
both sets will be `#Set<:integer>`s, as only the first `type` will be considered.

~Draft because it depends on #61~

Fixes #60 