### PR TITLE
Add support for inet type

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ field :home_phone, Exandra.UDT, type: :phone_number
 field :office_phone, Exandra.UDT, type: :phone_number
 ```
 
+### Inets
+
+Cassandra/Scylla has a native `inet` type which represents either an ipv4 or an ipv6 address.
+Exandra provides the `Exandra.Inet` type for these fields.
+
+```elixir
+field :last_ip, Exandra.Inet
+```
+
 ### Arrays
 
 You can use arrays with the Ecto `{:array, <type>}` type. This gets translated to the

--- a/lib/exandra.ex
+++ b/lib/exandra.ex
@@ -96,6 +96,15 @@ defmodule Exandra do
 
       field :home_phone, Exandra.EmbeddedType, cardinality: :many, using: MyApp.PhoneSchema
 
+  ### Inets
+
+  Cassandra/Scylla has a native `inet` type which represents either an ipv4 or an ipv6 address.
+  Exandra provides the `Exandra.Inet` type for these fields.
+
+  ```elixir
+  field :last_ip, Exandra.Inet
+  ```
+
   ### Arrays
 
   You can use arrays with the Ecto `{:array, <type>}` type. This gets translated to the

--- a/lib/exandra/inet.ex
+++ b/lib/exandra/inet.ex
@@ -1,0 +1,55 @@
+defmodule Exandra.Inet do
+  @moduledoc """
+  `Ecto.Type` for inets.
+
+  ## Examples
+
+      schema "devices" do
+        field :last_ip, Exandra.Inet
+      end
+
+  """
+
+  @typedoc """
+  The type for an Exandra inet.
+  """
+  @type t() :: :inet.ip_address()
+
+  @moduledoc since: "0.11.0"
+
+  use Ecto.Type
+
+  @impl Ecto.Type
+  def type, do: :inet
+
+  @impl Ecto.Type
+  def cast(ip) when is_tuple(ip), do: validate_ip(ip)
+
+  def cast(ip) when is_binary(ip) do
+    ip
+    |> String.to_charlist()
+    |> cast()
+  end
+
+  def cast(ip) when is_list(ip) do
+    case :inet.parse_address(ip) do
+      {:ok, ip} -> {:ok, ip}
+      _ -> :error
+    end
+  end
+
+  def cast(_), do: :error
+
+  @impl Ecto.Type
+  def load(ip) when is_tuple(ip), do: validate_ip(ip)
+
+  def load(_), do: :error
+
+  @impl Ecto.Type
+  def dump(ip) when is_tuple(ip), do: validate_ip(ip)
+  def dump(_), do: :error
+
+  defp validate_ip(ip) do
+    if :inet.is_ip_address(ip), do: {:ok, ip}, else: :error
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Exandra.MixProject do
         source_ref: "v#{@version}",
         source_url: @repo_url,
         groups_for_modules: [
-          "Ecto types": [Exandra.UDT, Exandra.Counter, Exandra.Map, Exandra.Set]
+          "Ecto types": [Exandra.UDT, Exandra.Counter, Exandra.Inet, Exandra.Map, Exandra.Set]
         ]
       ]
     ]

--- a/test/exandra/integration_test.exs
+++ b/test/exandra/integration_test.exs
@@ -30,7 +30,7 @@ defmodule Exandra.IntegrationTest do
       field :my_integer, :integer
       field :my_bool, :boolean
       field :my_decimal, :decimal
-      field :my_inet, Exandra.Tuple, types: [:integer, :integer, :integer, :integer]
+      field :my_inet, Exandra.Inet
 
       timestamps type: :utc_datetime
     end
@@ -255,7 +255,7 @@ defmodule Exandra.IntegrationTest do
     set1 = MapSet.new([1])
     set2 = MapSet.new([1, 2, 3])
     inet1 = {192, 168, 0, 1}
-    inet2 = {10, 0, 0, 1}
+    inet2 = {0xFE80, 0, 0, 0, 0, 0, 0, 1}
 
     schema1 = %Schema{
       id: row1_id,

--- a/test/exandra/types/inet_test.exs
+++ b/test/exandra/types/inet_test.exs
@@ -1,0 +1,37 @@
+defmodule Exandra.InetTest do
+  use Exandra.AdapterCase, async: true
+
+  alias Exandra.Inet
+
+  test "cast/1" do
+    assert {:ok, {127, 0, 0, 1}} == Ecto.Type.cast(Inet, {127, 0, 0, 1})
+    assert {:ok, {127, 0, 0, 1}} == Ecto.Type.cast(Inet, "127.0.0.1")
+    assert {:ok, {127, 0, 0, 1}} == Ecto.Type.cast(Inet, ~c"127.0.0.1")
+    assert :error == Ecto.Type.cast(Inet, {1_234_567, 0, 0, 1})
+    assert :error == Ecto.Type.cast(Inet, {127, 0, 0, "1"})
+
+    assert {:ok, {0, 0, 0, 0, 0, 0, 0, 1}} == Ecto.Type.cast(Inet, {0, 0, 0, 0, 0, 0, 0, 1})
+    assert {:ok, {0, 0, 0, 0, 0, 0, 0, 1}} == Ecto.Type.cast(Inet, "::1")
+    assert {:ok, {0, 0, 0, 0, 0, 0, 0, 1}} == Ecto.Type.cast(Inet, ~c"::1")
+    assert :error == Ecto.Type.cast(Inet, {0xFFFF0, 0, 0, 0, 0, 0, 0, 1})
+    assert :error == Ecto.Type.cast(Inet, "ffff0::1")
+  end
+
+  test "load/1" do
+    assert {:ok, {127, 0, 0, 1}} == Ecto.Type.load(Inet, {127, 0, 0, 1})
+    assert {:ok, {0, 0, 0, 0, 0, 0, 0, 1}} == Ecto.Type.load(Inet, {0, 0, 0, 0, 0, 0, 0, 1})
+    assert :error == Ecto.Type.load(Inet, {1_234_567, 0, 0, 1})
+    assert :error == Ecto.Type.load(Inet, {0xFFFF0, 0, 0, 0, 0, 0, 0, 1})
+  end
+
+  test "dump/1" do
+    assert {:ok, {127, 0, 0, 1}} == Ecto.Type.dump(Inet, {127, 0, 0, 1})
+    assert {:ok, {0, 0, 0, 0, 0, 0, 0, 1}} == Ecto.Type.dump(Inet, {0, 0, 0, 0, 0, 0, 0, 1})
+    assert :error == Ecto.Type.dump(Inet, {1_234_567, 0, 0, 1})
+    assert :error == Ecto.Type.dump(Inet, {0xFFFF0, 0, 0, 0, 0, 0, 0, 1})
+  end
+
+  test "type/0" do
+    assert Ecto.Type.type(Inet) == :inet
+  end
+end


### PR DESCRIPTION
While it was possible to use tuples for always ipv4 or always ipv6 addresses, it was not possible to handle the situation where either one could be fetched from the datatabase.

Using `Exandra.Inet`, both 4-element tuples and 8-element tuples will be accepted to/from the database.