### PR TITLE
feat: handle page streaming from query/4

### DIFF
--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -155,23 +155,9 @@ defmodule Exandra.Connection do
         other -> other
       end
 
-    case prepare_execute(cluster, sql, params, opts) do
-      {:ok, %Xandra.SchemaChange{} = schema_change} -> {:ok, schema_change}
-      {:ok, %Xandra.Void{}} -> {:ok, %{rows: nil, num_rows: 1}}
-      {:ok, %Xandra.Page{paging_state: nil} = page} -> {:ok, process_page(page)}
-      {:ok, %Xandra.Page{content: []}} -> {:ok, %{rows: [], num_rows: 1}}
-      {:error, _} = err -> err
+    with {:ok, _query, result} <- prepare_execute(cluster, _name = "", sql, params, opts) do
+      {:ok, result}
     end
-  end
-
-  defp prepare_execute(cluster, sql, params, opts) do
-    {prepare_opts, execute_opts} = split_prepare_and_execute_options(opts)
-
-    @xandra_cluster_mod.run(cluster, fn conn ->
-      with {:ok, %Prepared{} = prepared} <- @xandra_mod.prepare(conn, sql, prepare_opts) do
-        @xandra_mod.execute(conn, prepared, params, execute_opts)
-      end
-    end)
   end
 
   @doc false

--- a/test/exandra/prefix_test.exs
+++ b/test/exandra/prefix_test.exs
@@ -26,11 +26,13 @@ defmodule Exandra.PrefixTest do
       # We're only interested in the prepared statement here, so we stub execution
       stub(XandraMock, :execute, fn _conn, _stmt, _values, _opts -> {:ok, %Xandra.Void{}} end)
 
+      stub(XandraClusterMock, :run, fn _cluster, _opts, fun -> fun.(_conn = nil) end)
+
       :ok
     end
 
     test "adds a keyspace to the table" do
-      expect(XandraMock, :prepare, fn _conn, stmt, _opts ->
+      expect(XandraClusterMock, :prepare, fn _conn, stmt, _opts ->
         assert "INSERT INTO foo.my_schema (my_string, id) VALUES (?, ?) " = stmt
         {:ok, %Xandra.Prepared{}}
       end)
@@ -39,7 +41,7 @@ defmodule Exandra.PrefixTest do
     end
 
     test "can be overridden by query options" do
-      expect(XandraMock, :prepare, fn _conn, stmt, _options ->
+      expect(XandraClusterMock, :prepare, fn _conn, stmt, _options ->
         assert "INSERT INTO bar.my_schema (my_string, id) VALUES (?, ?) " = stmt
         {:ok, %Xandra.Prepared{}}
       end)


### PR DESCRIPTION
reuse existing `prepare_execute` function, which already handles page streaming.

this fixes some issues where xandra would return a paginated result, with exandra throwing an exception