### PR TITLE
fix(tuple): handle nil casting

### DIFF
--- a/lib/exandra/tuple.ex
+++ b/lib/exandra/tuple.ex
@@ -92,6 +92,8 @@ defmodule Exandra.Tuple do
     end
   end
 
+  def cast(nil, _), do: {:ok, nil}
+
   def cast(val, %{types: [type]}) do
     case Ecto.Type.cast(type, val) do
       {:ok, casted} -> {:ok, {casted}}

--- a/test/exandra/types/tuple_test.exs
+++ b/test/exandra/types/tuple_test.exs
@@ -42,9 +42,9 @@ defmodule Exandra.TupleTest do
   end
 
   test "cast/2" do
-    assert :error == Tuple.cast(nil, %{types: [:any, :any, :any]})
-
     assert :error = Tuple.cast({1}, %{types: [:string]})
+
+    assert {:ok, nil} == Tuple.cast(nil, %{types: [:any, :any, :any]})
 
     assert {:ok, {"a"}} == Tuple.cast({"a"}, %{types: [:string]})
     assert {:ok, {"a"}} == Tuple.cast("a", %{types: [:string]})


### PR DESCRIPTION
load/dump already handle nil this way.

default ecto modules cast to nil for nil values, tuples should behave the same way