### PR TITLE
chore: properly define `embed_as/2` for custom types

### DIFF
--- a/lib/exandra/map.ex
+++ b/lib/exandra/map.ex
@@ -137,7 +137,7 @@ defmodule Exandra.Map do
   def equal?(%{} = a, %{} = b, _), do: Map.equal?(a, b)
   def equal?(_, _, _), do: false
 
-  # From Ecto.Type.
   @doc false
-  def embed_as(_format), do: :self
+  @impl Ecto.ParameterizedType
+  def embed_as(_format, _opts), do: :self
 end

--- a/lib/exandra/set.ex
+++ b/lib/exandra/set.ex
@@ -134,9 +134,9 @@ defmodule Exandra.Set do
   def equal?(%MapSet{} = a, %MapSet{} = b, _), do: MapSet.equal?(a, b)
   def equal?(_, _, _), do: false
 
-  # From Ecto.Type
   @doc false
-  def embed_as(_format), do: :self
+  @impl Ecto.ParameterizedType
+  def embed_as(_format, _opts), do: :self
 
   defimpl Jason.Encoder, for: MapSet do
     def encode(set, opts) do

--- a/lib/exandra/tuple.ex
+++ b/lib/exandra/tuple.ex
@@ -161,7 +161,7 @@ defmodule Exandra.Tuple do
     end
   end
 
-  # From Ecto.Type
   @doc false
-  def embed_as(_format), do: :self
+  @impl Ecto.ParameterizedType
+  def embed_as(_format, _opts), do: :self
 end

--- a/test/exandra/types/map_test.exs
+++ b/test/exandra/types/map_test.exs
@@ -110,7 +110,7 @@ defmodule Exandra.MapTest do
     refute Map.equal?(true, true, nil)
   end
 
-  test "embed_as/1 returns :self" do
-    assert :self == Map.embed_as(nil)
+  test "embed_as/2 returns :self" do
+    assert :self == Map.embed_as(nil, nil)
   end
 end

--- a/test/exandra/types/set_test.exs
+++ b/test/exandra/types/set_test.exs
@@ -86,7 +86,7 @@ defmodule Exandra.SetTest do
     refute Set.equal?(true, true, nil)
   end
 
-  test "embed_as/1 returns :self" do
-    assert :self == Set.embed_as(nil)
+  test "embed_as/2 returns :self" do
+    assert :self == Set.embed_as(nil, nil)
   end
 end

--- a/test/exandra/types/tuple_test.exs
+++ b/test/exandra/types/tuple_test.exs
@@ -71,7 +71,7 @@ defmodule Exandra.TupleTest do
     assert {:ok, {1, "a"}} == Tuple.load({1, "a"}, %{types: [:integer, :string]})
   end
 
-  test "embed_as/1 returns :self" do
-    assert :self == Tuple.embed_as(nil)
+  test "embed_as/2 returns :self" do
+    assert :self == Tuple.embed_as(nil, nil)
   end
 end


### PR DESCRIPTION
the result is the same because ecto defaults to :self, but the function for ParameterizedTypes accepts two parameters so what was declared was never actually used