### PR TITLE
fix: uuid types in data structures

### DIFF
--- a/lib/exandra.ex
+++ b/lib/exandra.ex
@@ -358,16 +358,12 @@ defmodule Exandra do
 
   @doc false
   @impl Ecto.Adapter
-  def loaders(:binary_id, _type), do: []
-  def loaders(:exandra_map, type), do: [&Ecto.Type.embedded_load(type, &1, :exandra_map), type]
-  def loaders(:exandra_set, type), do: [&Ecto.Type.embedded_load(type, &1, :exandra_set), type]
+  def loaders(:binary_id, type), do: [Ecto.UUID, type]
 
   def loaders({:map, _}, type),
     do: [&decode_json/1, &Ecto.Type.embedded_load(type, &1, :map), type]
 
   def loaders(:map, type), do: [&decode_json/1, type]
-  # Xandra returns UUIDs as strings, so we don't need to do any loading.
-  def loaders(:uuid, _type), do: []
   def loaders(:decimal, type), do: [&decimal_decode/1, type]
   def loaders(_, type), do: [type]
 

--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -997,7 +997,12 @@ defmodule Exandra.Connection do
       |> apply_ecto_telemetry_options_to_xandra()
 
     prepare_opts = Keyword.take(opts, @xandra_prepare_opts)
-    execute_opts = Keyword.take(opts, @xandra_exec_opts)
+
+    execute_opts =
+      opts
+      |> Keyword.take(@xandra_exec_opts)
+      |> Keyword.put(:uuid_format, :binary)
+      |> Keyword.put(:timeuuid_format, :binary)
 
     {prepare_opts, execute_opts}
   end


### PR DESCRIPTION
the current implementation assumes xandra always returns strings and avoids loading uuids itself.

this usually works, but has a few drawbacks:
- we're forced to use embedded loaders for data structures, which should not be needed as the structures themselves declare their loaders
- these embedded loaders perform the UUID load themselves, attempting at loading a string UUID and resulting in an exception

By requiring xandra to send us UUIDs in binary format and performing the loading ourselves, we avoid the issue above.

The drawback of this is that it is no longer possible to request UUIDs in binary format to Xandra, but this did not work for values nested inside maps/sets even before this refactor