### PR TITLE
feat: support options for insertions

### DIFF
--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -225,7 +225,11 @@ defmodule Exandra.Connection do
   end
 
   @impl Ecto.Adapters.SQL.Connection
-  def insert(prefix, table, headers, rows, _on_conflict, _returning, opts) do
+  def insert(prefix, table, headers, rows, on_conflict, returning, placeholders) do
+    insert(prefix, table, headers, rows, on_conflict, returning, placeholders, [])
+  end
+
+  def insert(prefix, table, headers, rows, _on_conflict, _returning, _placeholders, opts) do
     keys = Enum.join(headers, ", ")
     values = Enum.map(rows, &Enum.map_join(&1, ", ", fn _ -> "?" end))
 


### PR DESCRIPTION
correctly build query from options by adding `Exandra.Connection.insert/7` which accepts options as the last parameter.

`Exandra.insert` and `Exandra.insert_all` are overwritten so that they can call this function instead of the default.

Closes #76

`Exandra.insert` and `Exandra.insert_all` (and `unzip_inserts`) have been taken from ecto_sql, which is licensed under the Apache 2.0 license.
Should I somehow mark these functions as being licensed under Apache?