### PR TITLE
chore: add missing typespec `t` types

### DIFF
--- a/lib/exandra/batch.ex
+++ b/lib/exandra/batch.ex
@@ -25,6 +25,8 @@ defmodule Exandra.Batch do
 
   """
 
+  @type t() :: %__MODULE__{queries: [{String.t(), list()}]}
+
   @enforce_keys [:queries]
   defstruct [:queries]
 end

--- a/lib/exandra/map.ex
+++ b/lib/exandra/map.ex
@@ -41,6 +41,10 @@ defmodule Exandra.Map do
 
   @opts_schema NimbleOptions.new!(opts_schema)
 
+  @type key() :: term()
+  @type value() :: term()
+  @type t() :: %{optional(key) => value}
+
   # Made public for testing.
   @doc false
   def params(embed), do: %{embed: embed}


### PR DESCRIPTION
define type `t` for Exandra.Map and Exandra.Batch