### PR TITLE
feat: support multiple updates in `update_all`

### DIFF
--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -248,7 +248,13 @@ defmodule Exandra.Connection do
   end
 
   defp updates(%Ecto.Query{updates: updates} = query) do
-    Enum.map_join(updates, ", ", fn %Ecto.Query.QueryExpr{expr: [set: [{field, expr}]]} ->
+    Enum.map_join(updates, ", ", fn %Ecto.Query.QueryExpr{expr: expressions} ->
+      Enum.map_join(expressions, ", ", &update_expression(query, &1))
+    end)
+  end
+
+  defp update_expression(query, {:set, fields}) do
+    Enum.map_join(fields, ", ", fn {field, expr} ->
       [quote_name(field), " = ", expr(expr, _sources = [], query)]
     end)
   end

--- a/test/exandra/connection_test.exs
+++ b/test/exandra/connection_test.exs
@@ -575,6 +575,10 @@ defmodule Exandra.ConnectionTest do
     query = from(m in Schema, update: [set: [x: 0]]) |> plan(:update_all)
 
     assert update_all(query) == ~s{UPDATE schema SET x = 0}
+
+    query = from(m in Schema, update: [set: [x: 0, y: 1], set: [z: 2]]) |> plan(:update_all)
+
+    assert update_all(query) == ~s{UPDATE schema SET x = 0, y = 1, z = 2}
   end
 
   test "update all with prefix" do


### PR DESCRIPTION
previously exandra would crash if an update_all was given a single update expression with multiple fields in the same `set:` or multiple `set:`s.