### PR TITLE
feat: implement checkout

### DIFF
--- a/lib/exandra.ex
+++ b/lib/exandra.ex
@@ -271,6 +271,22 @@ defmodule Exandra do
     conn_mod.checkout(cluster, fun, Keyword.merge(opts, meta.opts))
   end
 
+  def checkout(meta, opts, fun) when is_function(fun, 0) do
+    %{pid: cluster, opts: default_opts, sql: conn_mod} = meta
+
+    callback = fn conn ->
+      previous_conn = conn_mod.put_conn(cluster, conn)
+
+      try do
+        fun.()
+      after
+        conn_mod.reset_conn(cluster, previous_conn)
+      end
+    end
+
+    conn_mod.checkout(cluster, callback, Keyword.merge(opts, default_opts))
+  end
+
   use Ecto.Adapters.SQL, driver: :exandra
 
   @behaviour Ecto.Adapter.Storage
@@ -595,17 +611,15 @@ defmodule Exandra do
   def stream!(repo, sql, values, opts \\ []) do
     %{pid: cluster_pid} = Ecto.Repo.Registry.lookup(repo.get_dynamic_repo())
 
-    {prepare_opts, execute_opts} =
+    {_, execute_opts} =
       Exandra.Connection.split_prepare_and_execute_options(opts)
 
-    prepared = @xandra_cluster_mod.prepare!(cluster_pid, sql, prepare_opts)
+    {:ok, prepared} = Exandra.Connection.prepare(cluster_pid, sql, opts)
 
-    @xandra_cluster_mod.stream_pages!(
-      cluster_pid,
-      prepared,
-      values,
-      execute_opts
-    )
+    case Exandra.Connection.fetch_conn(cluster_pid) do
+      {:ok, conn} -> @xandra_mod.stream_pages!(conn, prepared, values, execute_opts)
+      :error -> @xandra_cluster_mod.stream_pages!(cluster_pid, prepared, values, execute_opts)
+    end
   end
 end
 

--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -103,10 +103,18 @@ defmodule Exandra.Connection do
 
   @impl Ecto.Adapters.SQL.Connection
   def prepare_execute(cluster, _name, stmt, params, opts) do
-    {prepare_opts, execute_opts} = split_prepare_and_execute_options(opts)
+    with {:ok, %Prepared{} = prepared} <- prepare(cluster, stmt, opts) do
+      execute(cluster, prepared, params, opts)
+    end
+  end
 
-    with {:ok, %Prepared{} = prepared} <- @xandra_cluster_mod.prepare(cluster, stmt, prepare_opts) do
-      execute(cluster, prepared, params, execute_opts)
+  @doc false
+  def prepare(cluster, stmt, opts) do
+    {prepare_opts, _} = split_prepare_and_execute_options(opts)
+
+    case fetch_conn(cluster) do
+      {:ok, conn} -> @xandra_mod.prepare(conn, stmt, prepare_opts)
+      :error -> @xandra_cluster_mod.prepare(cluster, stmt, prepare_opts)
     end
   end
 
@@ -115,21 +123,29 @@ defmodule Exandra.Connection do
     {_, execute_opts} = split_prepare_and_execute_options(opts)
     opts = remove_ecto_opts_for_xandra_execute_or_prepare(opts)
 
-    @xandra_cluster_mod.run(cluster, opts, fn conn ->
-      case @xandra_mod.execute(conn, query, params, execute_opts) do
-        {:ok, %Xandra.Void{}} ->
-          {:ok, query, %{rows: nil, num_rows: 1}}
+    case fetch_conn(cluster) do
+      {:ok, conn} ->
+        do_execute(conn, query, params, execute_opts)
 
-        {:ok, %Xandra.SchemaChange{}} ->
-          {:ok, query, %{rows: nil, num_rows: 1}}
+      :error ->
+        @xandra_cluster_mod.run(cluster, opts, &do_execute(&1, query, params, execute_opts))
+    end
+  end
 
-        {:ok, %Xandra.Page{} = page} ->
-          stream_pages(conn, query, params, execute_opts, page, %{rows: [], num_rows: 0})
+  defp do_execute(conn, query, params, execute_opts) do
+    case @xandra_mod.execute(conn, query, params, execute_opts) do
+      {:ok, %Xandra.Void{}} ->
+        {:ok, query, %{rows: nil, num_rows: 1}}
 
-        {:error, error} ->
-          {:error, error}
-      end
-    end)
+      {:ok, %Xandra.SchemaChange{}} ->
+        {:ok, query, %{rows: nil, num_rows: 1}}
+
+      {:ok, %Xandra.Page{} = page} ->
+        stream_pages(conn, query, params, execute_opts, page, %{rows: [], num_rows: 0})
+
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   defp stream_pages(conn, query, params, opts, page, acc) do
@@ -1106,4 +1122,25 @@ defmodule Exandra.Connection do
         Keyword.put(opts, :telemetry_metadata, xandra_meta)
     end
   end
+
+  def fetch_conn(cluster) do
+    case :erlang.get(key(cluster)) do
+      :undefined -> :error
+      conn -> {:ok, conn}
+    end
+  end
+
+  def put_conn(cluster, conn) do
+    Process.put(key(cluster), conn)
+  end
+
+  def reset_conn(cluster, previous_conn) do
+    if previous_conn do
+      put_conn(cluster, previous_conn)
+    else
+      Process.delete(key(cluster))
+    end
+  end
+
+  defp key(cluster), do: {__MODULE__, cluster}
 end

--- a/test/exandra/querying_test.exs
+++ b/test/exandra/querying_test.exs
@@ -25,6 +25,26 @@ defmodule Exandra.QueryingTest do
     :ok
   end
 
+  describe "checkout/3" do
+    test "runs all instructions in the same connection" do
+      conn = :custom_conn
+
+      XandraClusterMock
+      |> expect(:run, fn _cluster, _opts, fun -> fun.(conn) end)
+
+      XandraMock
+      |> expect(:prepare, fn ^conn, _stmt, _opts -> {:ok, %Xandra.Prepared{}} end)
+      |> expect(:execute, fn ^conn, _stmt, _values, _opts -> {:ok, %Xandra.Void{}} end)
+      |> expect(:prepare, fn ^conn, _stmt, _opts -> {:ok, %Xandra.Prepared{}} end)
+      |> expect(:execute, fn ^conn, _stmt, _values, _opts -> {:ok, %Xandra.Void{}} end)
+
+      TestRepo.checkout(fn ->
+        TestRepo.insert(%MySchema{my_string: "string"})
+        TestRepo.insert(%MySchema{my_string: "anotherstring"})
+      end)
+    end
+  end
+
   describe "querying" do
     test "create" do
       XandraMock


### PR DESCRIPTION
a custom implementation existed for running batches, but the normal `Repo.checkout` workflow wasn't implemented