### PR TITLE
feat: allow simple table options for create

### DIFF
--- a/lib/exandra/connection.ex
+++ b/lib/exandra/connection.ex
@@ -724,7 +724,7 @@ defmodule Exandra.Connection do
   def ddl_logs(_), do: []
 
   def table_options(opts, clustering_opts) when is_list(opts) do
-    with_opts = for {key, config} <- opts, into: [], do: "#{key} = #{sorta_jsonify_opts(config)}"
+    with_opts = for {key, config} <- opts, into: [], do: "#{key} = #{table_option_value(config)}"
 
     " WITH #{clustering_opts}" <> Enum.join(with_opts, " AND ")
   end
@@ -737,11 +737,15 @@ defmodule Exandra.Connection do
     clustering_opts
   end
 
-  def sorta_jsonify_opts(opts) do
-    opts = Enum.map_join(opts, ", ", fn {key, val} -> "'#{key}': '#{val}'" end)
+  defp table_option_value(opts) when is_map(opts) do
+    opts = Enum.map_join(opts, ", ", fn {key, val} -> "'#{key}': #{table_option_value(val)}" end)
 
     "{" <> opts <> "}"
   end
+
+  defp table_option_value(value) when is_integer(value), do: to_string(value)
+  defp table_option_value(value) when is_boolean(value), do: to_string(value)
+  defp table_option_value(value) when is_binary(value), do: "'#{value}'"
 
   @impl Ecto.Adapters.SQL.Connection
   def execute_ddl({command, %Table{} = table, columns})

--- a/test/exandra/connection_test.exs
+++ b/test/exandra/connection_test.exs
@@ -814,7 +814,7 @@ defmodule Exandra.ConnectionTest do
 
     assert execute_ddl(create) ==
              [
-               ~s|CREATE TABLE posts (id uuid, PRIMARY KEY (id)) WITH caching = {'enabled': 'true'}|
+               ~s|CREATE TABLE posts (id uuid, PRIMARY KEY (id)) WITH caching = {'enabled': true}|
              ]
 
     create =
@@ -823,7 +823,7 @@ defmodule Exandra.ConnectionTest do
 
     assert execute_ddl(create) ==
              [
-               ~s|CREATE TABLE posts (id uuid, PRIMARY KEY (id)) WITH caching = {'keys': 'NONE', 'rows_per_partition': '120'}|
+               ~s|CREATE TABLE posts (id uuid, PRIMARY KEY (id)) WITH caching = {'keys': 'NONE', 'rows_per_partition': 120}|
              ]
 
     create =
@@ -837,7 +837,22 @@ defmodule Exandra.ConnectionTest do
 
     assert execute_ddl(create) ==
              [
-               ~s|CREATE TABLE posts (id uuid, PRIMARY KEY (id)) WITH caching = {'keys': 'NONE', 'rows_per_partition': '120'} AND compactions = {'class': 'SizeTieredCompantionStrategy', 'min_threshold': '4'}|
+               ~s|CREATE TABLE posts (id uuid, PRIMARY KEY (id)) WITH caching = {'keys': 'NONE', 'rows_per_partition': 120} AND compactions = {'class': 'SizeTieredCompantionStrategy', 'min_threshold': 4}|
+             ]
+
+    create =
+      {:create,
+       table(:posts,
+         options: [
+           caching: %{enabled: true},
+           default_time_to_live: 7200,
+           speculative_retry: "10ms"
+         ]
+       ), [{:add, :id, :uuid, [primary_key: true]}]}
+
+    assert execute_ddl(create) ==
+             [
+               ~s|CREATE TABLE posts (id uuid, PRIMARY KEY (id)) WITH caching = {'enabled': true} AND default_time_to_live = 7200 AND speculative_retry = '10ms'|
              ]
   end
 


### PR DESCRIPTION
this adds support for simple table options without the need of using string options.

previously only maps where allowed as table options, as all values where assumed to be enums. however, some options are actually integers/strings/booleans.